### PR TITLE
Add Game.js unit tests

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -20,7 +20,7 @@ const shuffleDeck = (shuffle) => {
     for (let i = 1; i <= 100; i++) {
         deck.push(i);
     }
-    return shuffle(deck);;
+    return shuffle(deck);
 }
 
 const isLosingMove = (cardJustPlayed, players) => {
@@ -157,3 +157,14 @@ export const TheMind = {
 
     // plugins: [ PluginPlayer({ playerSetup: (id) => ({ cards: [], aboutToPlay: null }) })]
 }
+
+//For testing
+module.exports = {
+    isLosingMove,
+    isWinningMove,
+    isGameOver,
+    playCard,
+    aboutToPlay,
+    cancelPlay,
+    resetGame
+};

--- a/src/Game.js
+++ b/src/Game.js
@@ -23,7 +23,7 @@ const shuffleDeck = (shuffle) => {
     return shuffle(deck);
 }
 
-const isLosingMove = (cardJustPlayed, players) => {
+export const isLosingMove = (cardJustPlayed, players) => {
     const other = Object.keys(players).find(playerId => {
         const cards = players[playerId].cards;
         return cards.find(c => c < cardJustPlayed);
@@ -31,7 +31,7 @@ const isLosingMove = (cardJustPlayed, players) => {
     return !!other;
 }
 
-const isWinningMove = (players) => {
+export const isWinningMove = (players) => {
     const remaining = Object.keys(players).find(playerId => {
         const cards = players[playerId].cards;
         return cards.length > 0;
@@ -39,7 +39,7 @@ const isWinningMove = (players) => {
     return !remaining;
 }
 
-const isGameOver = (G) => {
+export const isGameOver = (G) => {
     console.log("checking endgame");
     if (G.cardsPlayed.length === 0) {
         console.log("init");
@@ -70,7 +70,7 @@ const setupGame = (ctx) => {
 }
 
 // moves
-const playCard = (G, ctx, card) => {
+export const playCard = (G, ctx, card) => {
     console.log(`${ctx.playerID} played`);
     const playerId = ctx.playerID;
     const playedCard = G.players[playerId].cards[card];
@@ -92,7 +92,7 @@ const playCard = (G, ctx, card) => {
     return newG;
 };
 
-const aboutToPlay = (G, ctx) => {
+export const aboutToPlay = (G, ctx) => {
     return {
         ...G,
         aboutToPlay: {
@@ -102,7 +102,7 @@ const aboutToPlay = (G, ctx) => {
     }
 };
 
-const cancelPlay = (G, ctx) => {
+export const cancelPlay = (G, ctx) => {
     return {
         ...G,
         aboutToPlay: {
@@ -112,7 +112,7 @@ const cancelPlay = (G, ctx) => {
     }
 };
 
-const resetGame = (G, ctx) => {
+export const resetGame = (G, ctx) => {
     return setupGame(ctx);
 }
 
@@ -157,14 +157,3 @@ export const TheMind = {
 
     // plugins: [ PluginPlayer({ playerSetup: (id) => ({ cards: [], aboutToPlay: null }) })]
 }
-
-//For testing
-module.exports = {
-    isLosingMove,
-    isWinningMove,
-    isGameOver,
-    playCard,
-    aboutToPlay,
-    cancelPlay,
-    resetGame
-};

--- a/src/Game.test.js
+++ b/src/Game.test.js
@@ -1,5 +1,5 @@
 
-const {
+import {
     isLosingMove,
     isWinningMove,
     isGameOver,
@@ -7,47 +7,32 @@ const {
     aboutToPlay,
     cancelPlay,
     resetGame
-} = require('./Game')
-
-const G = {
-    players: {
-        1: {
-            cards: [67, 92]
-        },
-        2: {
-            cards: [45, 99]
-        }
-    },
-    aboutToPlay: {
-        1: null
-    },
-    cardsPlayed: [3],
-}
+} from './Game';
 
 describe('Game unit tests', () => {
     it('player 1\'s move should lose the game', () => {
         const cardJustPlayed = 20;
-        G.players = {
+        const players = {
             1: {
                 cards: [10, 35]
             }
         }
-        expect(isLosingMove(cardJustPlayed, G.players)).toBe(true);
+        expect(isLosingMove(cardJustPlayed, players)).toBe(true);
     });
 
     it('is not a losing move played by player 1', () => {
         const cardJustPlayed = 5;
-        G.players = {
+        const players = {
             1: {
                 cards: [10, 35]
             }
         }
-        expect(isLosingMove(cardJustPlayed, G.players)).toBe(false);
+        expect(isLosingMove(cardJustPlayed, players)).toBe(false);
     });
 
     it('is not a losing move played by player 1 edge case', () => {
         const cardJustPlayed = 9;
-        G.players = {
+        const players = {
             1: {
                 cards: [10, 35]
             },
@@ -55,13 +40,13 @@ describe('Game unit tests', () => {
                 cards: [11, 12]
             }
         }
-        expect(isLosingMove(cardJustPlayed, G.players)).toBe(false);
+        expect(isLosingMove(cardJustPlayed, players)).toBe(false);
     });
 
     it('player 1 can win if no cards left', () => {
-        G.players = { 1: { cards: [] } }
+        const players = { 1: { cards: [] } }
 
-        expect(isWinningMove(G.players)).toBe(true);
+        expect(isWinningMove(players)).toBe(true);
     })
 
     it('Player 1 can play winning move', () => {
@@ -71,32 +56,41 @@ describe('Game unit tests', () => {
             numPlayers: 2,
             playerID: 1
         }
+        const G = {
+            players: {
+                1: { cards: [15] }
+            },
+            cardsPlayed: [3],
+        }
 
-        const newG = playCard(G, ctx, G.players[1].cards[0]);
+        const newG = playCard(G, ctx, 0);
         expect(newG.gameOver).toBe('You win!');
     })
 
     it('game should not be over, should be init', () => {
-        G.cardsPlayed = [];
+        const cardsPlayed = [];
 
-        expect(isGameOver(G)).toBeUndefined();
+        expect(isGameOver({ cardsPlayed })).toBeUndefined();
     });
 
     it('game should be over - player won the game', () => {
-        G.cardsPlayed = [3];
+        const G = {
+            players: {
+                1: { cards: [] }
+            },
+            cardsPlayed: [3],
+        }
         expect(isGameOver(G)).toBe('You win!');
     })
 
     it('game should be over - player lost the game', () => {
-        G.players = {
-            1: {
-                cards: [10, 35]
+        const G = {
+            players: {
+                1: { cards: [5] }
             },
-            2: {
-                cards: [11, 12]
-            }
+            cardsPlayed: [3, 10, 20, 53],
         }
-        G.cardsPlayed = [3, 52, 90];
+
         expect(isGameOver(G)).toBe("Game Over!");
     })
 
@@ -106,6 +100,16 @@ describe('Game unit tests', () => {
             currentPlayer: '1',
             numPlayers: 2,
             playerID: 1
+        }
+
+        const G = {
+            players: {
+                1: { cards: [15] }
+            },
+            aboutToPlay: {
+                1: null
+            },
+            cardsPlayed: [3],
         }
 
         const newG = playCard(G, ctx, G.players[1].cards[0]);
@@ -120,6 +124,12 @@ describe('Game unit tests', () => {
             numPlayers: 2,
             playerID: 1
         }
+        const G = {
+            players: {
+                1: { cards: [15] }
+            },
+            cardsPlayed: [3],
+        }
         expect(aboutToPlay(G, ctx)).toBeDefined();
     })
 
@@ -129,6 +139,12 @@ describe('Game unit tests', () => {
             currentPlayer: '1',
             numPlayers: 2,
             playerID: 1
+        }
+        const G = {
+            players: {
+                1: { cards: [15] }
+            },
+            cardsPlayed: [3],
         }
         expect(cancelPlay(G, ctx)).toBeDefined();
     })
@@ -143,6 +159,12 @@ describe('Game unit tests', () => {
             random: {
                 Shuffle(d) { return d }
             }
+        }
+        const G = {
+            players: {
+                1: { cards: [15] }
+            },
+            cardsPlayed: [3],
         }
         const newGame = resetGame(G, ctx);
 

--- a/src/Game.test.js
+++ b/src/Game.test.js
@@ -1,0 +1,154 @@
+
+const {
+    isLosingMove,
+    isWinningMove,
+    isGameOver,
+    playCard,
+    aboutToPlay,
+    cancelPlay,
+    resetGame
+} = require('./Game')
+
+const G = {
+    players: {
+        1: {
+            cards: [67, 92]
+        },
+        2: {
+            cards: [45, 99]
+        }
+    },
+    aboutToPlay: {
+        1: null
+    },
+    cardsPlayed: [3],
+}
+
+describe('Game unit tests', () => {
+    it('player 1\'s move should lose the game', () => {
+        const cardJustPlayed = 20;
+        G.players = {
+            1: {
+                cards: [10, 35]
+            }
+        }
+        expect(isLosingMove(cardJustPlayed, G.players)).toBe(true);
+    });
+
+    it('is not a losing move played by player 1', () => {
+        const cardJustPlayed = 5;
+        G.players = {
+            1: {
+                cards: [10, 35]
+            }
+        }
+        expect(isLosingMove(cardJustPlayed, G.players)).toBe(false);
+    });
+
+    it('is not a losing move played by player 1 edge case', () => {
+        const cardJustPlayed = 9;
+        G.players = {
+            1: {
+                cards: [10, 35]
+            },
+            2: {
+                cards: [11, 12]
+            }
+        }
+        expect(isLosingMove(cardJustPlayed, G.players)).toBe(false);
+    });
+
+    it('player 1 can win if no cards left', () => {
+        G.players = { 1: { cards: [] } }
+
+        expect(isWinningMove(G.players)).toBe(true);
+    })
+
+    it('Player 1 can play winning move', () => {
+        const ctx = {
+            turn: 4,
+            currentPlayer: '1',
+            numPlayers: 2,
+            playerID: 1
+        }
+
+        const newG = playCard(G, ctx, G.players[1].cards[0]);
+        expect(newG.gameOver).toBe('You win!');
+    })
+
+    it('game should not be over, should be init', () => {
+        G.cardsPlayed = [];
+
+        expect(isGameOver(G)).toBeUndefined();
+    });
+
+    it('game should be over - player won the game', () => {
+        G.cardsPlayed = [3];
+        expect(isGameOver(G)).toBe('You win!');
+    })
+
+    it('game should be over - player lost the game', () => {
+        G.players = {
+            1: {
+                cards: [10, 35]
+            },
+            2: {
+                cards: [11, 12]
+            }
+        }
+        G.cardsPlayed = [3, 52, 90];
+        expect(isGameOver(G)).toBe("Game Over!");
+    })
+
+    it('Player 1 can play a card', () => {
+        const ctx = {
+            turn: 2,
+            currentPlayer: '1',
+            numPlayers: 2,
+            playerID: 1
+        }
+
+        const newG = playCard(G, ctx, G.players[1].cards[0]);
+        expect(newG).toBeDefined();
+    })
+
+
+    it('player 1 about to play', () => {
+        const ctx = {
+            turn: 2,
+            currentPlayer: '1',
+            numPlayers: 2,
+            playerID: 1
+        }
+        expect(aboutToPlay(G, ctx)).toBeDefined();
+    })
+
+    it('cancel play', () => {
+        const ctx = {
+            turn: 2,
+            currentPlayer: '1',
+            numPlayers: 2,
+            playerID: 1
+        }
+        expect(cancelPlay(G, ctx)).toBeDefined();
+    })
+
+    it('can reset game', () => {
+        //ctx object for testing purposes
+        const ctx = {
+            turn: 2,
+            currentPlayer: '1',
+            numPlayers: 2,
+            playerID: 1,
+            random: {
+                Shuffle(d) { return d }
+            }
+        }
+        const newGame = resetGame(G, ctx);
+
+        expect(Object.keys(newGame.players)).toHaveLength(2);
+        expect(newGame.players[0].cards).toHaveLength(1);
+        expect(newGame.aboutToPlay).toStrictEqual({});
+        expect(newGame.gameOver).toBe(false);
+    })
+});


### PR DESCRIPTION
This PR will add unit tests for the Game.js methods. 

A few notes: 
  * This lays out a test suite for most of the methods in Game.js and should be reviewed by someone who has a deep knowledge of the game and app logic. I did my best on the assertions but they may need to be updated
  * There is a failed test in App.test.js if you run `npm run test`. This looks like a default React-App test and can likely be removed
  * the `G` and `ctx` objects from `boardgame.io js` library need to be mocked in the test suite
  * All tested methods were moved to a `module.exports = {}` block in Game.js so they are accessible in Game.test.js