### PR TITLE
[#5] feat: position cards in same place where dropped

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,7 @@ const App = () => {
         lobbyServer={server}
         gameComponents={[{game: TheMind, board: Board}]}
         // debug={true}
-      />;
+      />
     </div>
   );
 }

--- a/src/Board.js
+++ b/src/Board.js
@@ -9,7 +9,17 @@ const DropTypes = {
 const DropZone = props => {
     const [, drop] = useDrop({
         accept: DropTypes.CARD,
-        drop: () => { console.log("dropped on board"); props.onDrop(); }
+        drop: (item, monitor) => {
+            console.log("dropped on board");
+            props.onDrop();
+            props.moves.addCardPosition({
+                ...monitor.getClientOffset(),
+                screenWidth: window.innerWidth,
+                screenHeight: window.innerHeight,
+                scrollX: window.pageXOffset,
+                scrollY: window.pageYOffset
+            })
+        },
     });
     console.log(props.cardsPlayed)
 
@@ -22,27 +32,26 @@ const DropZone = props => {
                     backgroundColor: 'lightgrey',
                     width: '100%',
                     height: '400px',
-                    display: 'flex',
-                    justifyContent: 'center',
+                    display: 'block',
                 }}
             >
                 {props.cardsPlayed.length > 0 ?
 
 
-                        props.cardsPlayed.map((card) => (<div
-                            key={`card-${card.toString()}`} style={{
-                                color: 'black',
-                                background: 'aliceblue',
-                                fontSize: '24pt',
-                                width: '40px',
-                                padding: '4px 15px',
-                                marginRight: '10px',
-                                border: '1px solid #000',
-                                textAlign: 'center',
-                                alignSelf: 'center',
-                            }}
-                        >{card}</div>))
-
+                    props.cardsPlayed.map((card, i) => (<div
+                        key={card} style={{
+                            color: 'black',
+                            background: 'aliceblue',
+                            fontSize: '24pt',
+                            width: '80px',
+                            height: '36px',
+                            border: '1px solid #000',
+                            textAlign: 'center',
+                            position: 'absolute',
+                            top: props.cardPositions[i] ? `${(props.cardPositions[i].y + props.cardPositions[i].scrollY) / (props.cardPositions[i].screenHeight + props.cardPositions[i].scrollY + 38) * 100}%`: 'auto',
+                            left: props.cardPositions[i] ? `${(props.cardPositions[i].x + props.cardPositions[i].scrollX) / (props.cardPositions[i].screenWidth + props.cardPositions[i].scrollX + 82) * 100}%`: 'auto'
+                        }}
+                    >{card}</div>))
                     : null
                 }
             </div>
@@ -76,7 +85,7 @@ const Card = props => {
 
 const Hand = props => {
     return (
-        <div>
+        <div style={{ minHeight: '40px' }}>
             Your cards:
             <div
                 style={{
@@ -129,6 +138,8 @@ export const Board = props => {
 
             <DropZone
                 cardsPlayed={props.G.cardsPlayed}
+                cardPositions={props.G.cardPositions}
+                moves={props.moves}
                 onDrop={() => props.moves.playCard(0)}
             />
             <Hand

--- a/src/Game.js
+++ b/src/Game.js
@@ -100,7 +100,7 @@ const addCardPosition = (G, ctx, cardPosition) => {
     }
 }
 
-const aboutToPlay = (G, ctx) => {
+export const aboutToPlay = (G, ctx) => {
     return {
         ...G,
         aboutToPlay: {

--- a/src/Game.js
+++ b/src/Game.js
@@ -61,6 +61,7 @@ const setupGame = (ctx) => {
         players: {},
         aboutToPlay: {},
         cardsPlayed: [],
+        cardPositions: [],
         gameOver: false,
     };
     for (let i = 0; i < ctx.numPlayers; i++) {
@@ -91,6 +92,13 @@ const playCard = (G, ctx, card) => {
     newG.gameOver = isGameOver(newG);
     return newG;
 };
+
+const addCardPosition = (G, ctx, cardPosition) => {
+    return {
+        ...G,
+        cardPositions: [...G.cardPositions, cardPosition]
+    }
+}
 
 const aboutToPlay = (G, ctx) => {
     return {
@@ -125,6 +133,7 @@ export const TheMind = {
         aboutToPlay,
         cancelPlay,
         playCard,
+        addCardPosition,
         resetGame,
     },
 

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+#lobby-view {
+  position: relative;
+}


### PR DESCRIPTION
Adds feat described in issue #5:
- Adds`cardPosition` property and game move to `gameState` in `Game.js` to correctly position card when dropped regardless of screen height, width and scroll distance (X or Y)
- Adds `addCardPosition()` game move to Drop Zone in `Board.js` to add card position to state when card is successfully dropped
- Adds relative styling to lobby div in`index.css` for absolute positioning of cards
- Removes semicolon from `App.js` that was printed out at the bottom of the game