### PR TITLE
[#1] - show num of player cards remaining

### DIFF
--- a/src/Board.js
+++ b/src/Board.js
@@ -120,7 +120,7 @@ const PlayerList = props => {
             key={playerId}
             style={{ color: props.aboutToPlay[playerId] ? 'red' : 'black' }}
           >
-            {name}
+            {name} ({props.players[playerId].cards.length} {props.players[playerId].cards.length === 1 ? 'card' : 'cards'} remaining)
           </div>
         )
       })}
@@ -145,6 +145,7 @@ export const Board = props => {
       <div>
         <PlayerList
           allPlayers={props.matchData}
+          players={props.G.players}
           currentPlayerId={props.playerID}
           aboutToPlay={props.G.aboutToPlay}
         />


### PR DESCRIPTION
Adds feat described in issue #1: 
- Add player cards remaining next to player names in `PlayerList` in `Board.js`